### PR TITLE
Upgrade to the latest version of Python3 available from the package manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apk --update --no-cache --quiet upgrade
 # longer install times.
 ###
 ENV DEPS \
-    python3=3.10.13-r0
+    python3=3.10.14-r1
 RUN apk --no-cache --quiet add ${DEPS}
 
 ###


### PR DESCRIPTION
## 🗣 Description ##

This pull request upgrades to the latest version of the `python3` package available from the package manager.

## 💭 Motivation and context ##

The previous version of Python 3 is no longer available from the package manager used by the `certbot/dns-route53` base image.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All new and existing tests pass.